### PR TITLE
Install coveralls inside cirlceci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: pytest . --ignore=earthshot/tests/test_ee_api.py --cov=earthshot
       - run:
           name: Report coverage
-          command: coveralls --verbose
+          command: pip install coveralls && coveralls --verbose
 
 workflows:
   main:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Earthshot
 
+[![Coverage Status](https://coveralls.io/repos/github/earthshot-labs/earthshot/badge.svg)](https://coveralls.io/github/earthshot-labs/earthshot)
+
 A central python package for projects at Eartshot Labs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 bokeh>=2.2.3
 coverage>=5.4.0
-coveralls>=3.0.0
 earthengine-api>=0.1.243
 folium>=0.11.0
 google-auth>=1.24.0


### PR DESCRIPTION
I removed coveralls from `requirements.txt` and instead install it inside circleci. Python orb doesn't include binaries located inside `~/.local/bin` when building cache, which results in "command not found" error when running `coveralls`.